### PR TITLE
feat: add get status enpoint both by category and by platform

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -106,3 +106,23 @@ paths:
                     description: "Bad request"
                 500:
                     description: "Internal Server Error"
+    "/status":
+        post:
+            tags:
+                - statuses
+            consumes:
+                - application/json
+            parameters:
+                - in: body
+                  name: status
+                  schema:
+                    type: object                   
+            produces:
+                - application/json
+            responses:
+                200:
+                    description: "Success"
+                400:
+                    description: "Bad request"
+                500:
+                    description: "Internal Server Error"

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -2,3 +2,4 @@ from .index import IndexView
 from .category import CategoryView
 from .platform import PlatformView
 from .cron import CronView
+from .status import StatusView

--- a/app/controllers/cron.py
+++ b/app/controllers/cron.py
@@ -85,9 +85,3 @@ def save2db(id, n_status):
         print("Sarri failed to update")
 
     print("Status successfuly updated!!!")
-    # return dict(
-    #         status="success",
-    #         message=f"Platform status updated successfully"
-    #         ), 200
-
-# get_data()

--- a/app/controllers/status.py
+++ b/app/controllers/status.py
@@ -1,0 +1,98 @@
+import json
+from flask import current_app
+from flask_restful import Resource, request
+from app.schemas.category import CategorySchema
+from app.models.category import Category
+from app.schemas.platform import PlatformSchema
+from app.models.platform import Platform
+
+class StatusView(Resource):
+    def post(self):
+        """
+        """
+
+        google_data = request.get_json()
+        if(google_data):
+            choice = google_data['queryResult']['parameters']['number']
+        else:
+            choice = 3 # mannually set the choice if not sent in request
+        
+        
+        if choice == 1 or choice == 2:
+            # check for platform one
+            platform_schema = PlatformSchema()
+
+            platforms = Platform.get_by_id(choice)
+            platforms_data, errors = platform_schema.dumps(platforms)
+
+            if errors:
+                return dict(status='fail', message=errors), 500
+
+            # construct response 
+            response_list = []
+            platform_list = json.loads(platforms_data)
+            name = platform_list['name']
+            if platform_list['status']:
+                message = " is currently blocked"
+            else:
+                message = " is up and running"
+            response_list.append( name  + message + " as of "+ platform_list['status_date'])
+
+            final_list = []
+            final_list.append(dict(text = dict(text=response_list)))
+
+
+            return dict(fulfillmentMessages=final_list),200
+
+        elif choice == 3 or choice == 4:
+            platform_schema = PlatformSchema(many=True)
+            
+            if choice == 3:
+                category_id = 1 #socials category
+            else:
+                category_id = 2  #vpn category
+
+            category = Category.get_by_id(category_id)
+            print("category is",category)
+
+            if not category:
+                return dict(status='fail', message=f'category {category_id} not found'), 404
+            
+            platforms = Platform.find_all(category_id=category_id)
+        
+            platforms_data, errors = platform_schema.dumps(platforms)
+            
+            if errors:
+                print(errors)
+                return dict(status='fail', message=errors), 500
+
+            # construct response 
+            response_list = []
+            platforms_data_list = json.loads(platforms_data)
+            if not platforms_data_list:
+                response_list.append("No platforms yet in this category")
+            
+            if platforms_data_list:
+                for platform in platforms_data_list:
+                    if platform['status']:
+                        message = " is currently blocked"
+                    else:
+                        message = " is up and running"
+                    response_list.append( platform['name']  + message + " as of "+ platform['status_date'])
+
+            final_list = []
+            final_list.append(dict(text = dict(text=response_list)))
+
+            return dict(
+                fulfillmentMessages=final_list),200
+        else:
+            response_list = []
+            response_list.append("Sorry I didn't get that choice. Try another on the menu. For Facebook press 1, For Twitter press 2, For all social platforms press 3, For all vpn checks press 4")
+
+            final_list = []
+            final_list.append(dict(text = dict(text=response_list)))
+
+            return dict(fulfillmentMessages=final_list),200
+
+
+

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,6 +1,6 @@
 from flask_restful import Api
 from app.controllers import (
-    IndexView, CategoryView, PlatformView, CronView
+    IndexView, CategoryView, PlatformView, CronView, StatusView
     )
 
 api = Api()
@@ -14,5 +14,8 @@ api.add_resource(CategoryView, '/categories', endpoint='categories')
 # Platform routes
 api.add_resource(PlatformView, '/platforms', endpoint='platforms')
 
-# 
+# cron to update statuses
 api.add_resource(CronView, '/cron', endpoint='crons')
+
+# 
+api.add_resource(StatusView, '/status', endpoint='statuses')


### PR DESCRIPTION
### What does this PR do?

- It adds a status endpoint that is used by ES as a weebhook
- This endpoint gets status by either platform or by category depending on what the user selects.

### Which issue does it address?

- Issue #6 and #5 